### PR TITLE
Daniel gpio extend

### DIFF
--- a/movement/lane_stepper.py
+++ b/movement/lane_stepper.py
@@ -74,7 +74,8 @@ class ItemLaneStepper:
                 else:
                     print("Unexpected direction--should be \'cw\' or \'ccw\'")
                     exit(1)
-
+				
+                #print(self.motor_pins)
                 time.sleep(step_sleep)
 
         except KeyboardInterrupt:
@@ -111,27 +112,43 @@ def main():
 		
 				# Switch the pins to output mode (default value assumed False)
 				pins[i][j].switch_to_output(value=False)
-				pins[i][j].pull = digitalio.Pull.UP
+				#pins[i][j].pull = digitalio.Pull.UP
 
 		return pins
 
-	def move(my_stepper):
+	def move():
+		p = i2c_setup()
+		my_stepper = ItemLaneStepper(p[0][0], p[0][1], p[0][2], p[0][3], FULL_STEP)
 		my_stepper.rotate('cw', 1000000, 0.5)
 		my_stepper.rotate('ccw', 1000000, 1)
 		my_stepper.rotate('cw', 1000000, 1)
 		my_stepper.reset()
 
-	p = i2c_setup()
 
-	my_stepper_A = ItemLaneStepper(p[0][0], p[0][1], p[0][2], p[0][3], FULL_STEP)
-	my_stepper_B = ItemLaneStepper(p[1][0], p[1][1], p[1][2], p[1][3], FULL_STEP)
+	def move1():
+		p = i2c_setup()
+		my_stepper = ItemLaneStepper(p[1][0], p[1][1], p[1][2], p[1][3], FULL_STEP)
+		my_stepper.rotate('cw', 1000000, 0.5)
+		my_stepper.rotate('ccw', 1000000, 1)
+		my_stepper.rotate('cw', 1000000, 1)
+		my_stepper.reset()
 
-	thread_A = threading.Thread(target=move, args=(my_stepper_A,))
-	thread_B = threading.Thread(target=move, args=(my_stepper_B,))
+	#p = i2c_setup()
+
+	#my_stepper_A = ItemLaneStepper(p[0][0], p[0][1], p[0][2], p[0][3], FULL_STEP)
+	#my_stepper_B = ItemLaneStepper(p[1][0], p[1][1], p[1][2], p[1][3], FULL_STEP)
+	#my_stepper_C = ItemLaneStepper(p[1][4], p[1][5], p[1][6], p[1][7], FULL_STEP)
+	
+
+	thread_A = threading.Thread(target=move)
+	thread_B = threading.Thread(target=move1)
+	#thread_B = threading.Thread(target=move, args=(my_stepper_B,))
+	#thread_C = threading.Thread(target=move, args=(my_stepper_C,))
 
 	try:
 		thread_A.start()
 		thread_B.start()
+		#thread_C.start()
 	except:
 		print("Unable to start a new thread")
 

--- a/movement/lane_stepper.py
+++ b/movement/lane_stepper.py
@@ -111,13 +111,14 @@ def main():
 		
 				# Switch the pins to output mode (default value assumed False)
 				pins[i][j].switch_to_output(value=False)
+				pins[i][j].pull = digitalio.Pull.UP
 
 		return pins
 
 	def move(my_stepper):
-		my_stepper.rotate('cw', 1000, 0.5)
-		my_stepper.rotate('ccw', 1000, 1)
-		my_stepper.rotate('cw', 1000, 1)
+		my_stepper.rotate('cw', 1000000, 0.5)
+		my_stepper.rotate('ccw', 1000000, 1)
+		my_stepper.rotate('cw', 1000000, 1)
 		my_stepper.reset()
 
 	p = i2c_setup()

--- a/movement/lane_stepper.py
+++ b/movement/lane_stepper.py
@@ -123,14 +123,14 @@ def main():
 	p = i2c_setup()
 
 	my_stepper_A = ItemLaneStepper(p[0][0], p[0][1], p[0][2], p[0][3], FULL_STEP)
-	my_stepper_B = ItemLaneStepper(p[0][4], p[0][5], p[0][6], p[0][7], FULL_STEP)
+	my_stepper_B = ItemLaneStepper(p[1][0], p[1][1], p[1][2], p[1][3], FULL_STEP)
 
 	thread_A = threading.Thread(target=move, args=(my_stepper_A,))
 	thread_B = threading.Thread(target=move, args=(my_stepper_B,))
 
 	try:
 		thread_A.start()
-		#thread_B.start()
+		thread_B.start()
 	except:
 		print("Unable to start a new thread")
 

--- a/movement/lane_stepper.py
+++ b/movement/lane_stepper.py
@@ -52,7 +52,7 @@ class ItemLaneStepper:
     #
     # Parameters:
     # -direction: 'cw' for clockwise or 'ccw' for counterclockwise movement
-    # -speed: used to determine how quickly each step takes--bounded between [0, 1500]
+    # -speed: used to determine how quickly each step takes--bounded between [0, ???]
     # -rotations: number of rotations to undertake
     def rotate(self, direction:str, speed:int, rotations:float):
         step_sleep = 1 / speed;
@@ -82,6 +82,10 @@ class ItemLaneStepper:
                 self.motor_pins[pin].value = False
             exit(1)
 
+    def reset(self):
+        for pin in range(0, len(self.motor_pins)):
+            self.motor_pins[pin].value=False
+
 # A test script to play with the functionality of the stepper motors for the item lanes
 def main():
 	# Will need to initialize pins first before going in and using them per stepper (perhaps
@@ -110,15 +114,25 @@ def main():
 
 		return pins
 
+	def move(my_stepper):
+		my_stepper.rotate('cw', 1000, 0.5)
+		my_stepper.rotate('ccw', 1000, 1)
+		my_stepper.rotate('cw', 1000, 1)
+		my_stepper.reset()
+
 	p = i2c_setup()
 
-	my_stepper = ItemLaneStepper(p[0][0], p[0][1], p[0][2], p[0][3], FULL_STEP)
+	my_stepper_A = ItemLaneStepper(p[0][0], p[0][1], p[0][2], p[0][3], FULL_STEP)
+	my_stepper_B = ItemLaneStepper(p[0][4], p[0][5], p[0][6], p[0][7], FULL_STEP)
 
-	my_stepper.rotate('cw', 1500, 0.5)
-	my_stepper.rotate('ccw', 1500, 1)
-	my_stepper.rotate('cw', 1500, 1)
+	thread_A = threading.Thread(target=move, args=(my_stepper_A,))
+	thread_B = threading.Thread(target=move, args=(my_stepper_B,))
 
-	my_stepper.reset()
+	try:
+		thread_A.start()
+		#thread_B.start()
+	except:
+		print("Unable to start a new thread")
 
 if __name__ == '__main__':
     main()

--- a/movement/lane_stepper.py
+++ b/movement/lane_stepper.py
@@ -128,9 +128,7 @@ def i2c_setup():
 # A test script to play with the functionality of the stepper motors for the item lanes
 def main():
 	def move(my_stepper):
-		my_stepper.rotate('cw', 1000000000, 0.5)
-		my_stepper.rotate('ccw', 1000000000, 1)
-		my_stepper.rotate('cw', 1000000000, 1)
+		my_stepper.rotate('cw', 15000, 1)
 		my_stepper.reset()
 
 	my_stepper_A = ItemLaneStepper(0, FULL_STEP)

--- a/movement/lane_stepper.py
+++ b/movement/lane_stepper.py
@@ -15,7 +15,7 @@ import threading
 import time
 from adafruit_mcp230xx.mcp23017 import MCP23017
 
-MCP_TOTAL = 2											# How many MCP23017 boards are connected
+MCP_TOTAL = 3											# How many MCP23017 boards are connected
 PINS_PER_MCP = 16										# Number of GPIOs per MCP
 
 # Define the sequence for the full step (more granular) rotation
@@ -133,6 +133,15 @@ def main():
 		my_stepper.rotate('cw', 1000000, 1)
 		my_stepper.reset()
 
+	def move2():
+		p = i2c_setup()
+		my_stepper = ItemLaneStepper(p[2][0], p[2][1], p[2][2], p[2][3], FULL_STEP)
+		my_stepper.rotate('cw', 1000000, 0.5)
+		my_stepper.rotate('ccw', 1000000, 1)
+		my_stepper.rotate('cw', 1000000, 1)
+		my_stepper.reset()
+
+
 	#p = i2c_setup()
 
 	#my_stepper_A = ItemLaneStepper(p[0][0], p[0][1], p[0][2], p[0][3], FULL_STEP)
@@ -142,13 +151,14 @@ def main():
 
 	thread_A = threading.Thread(target=move)
 	thread_B = threading.Thread(target=move1)
+	thread_C = threading.Thread(target=move2)
 	#thread_B = threading.Thread(target=move, args=(my_stepper_B,))
 	#thread_C = threading.Thread(target=move, args=(my_stepper_C,))
 
 	try:
 		thread_A.start()
 		thread_B.start()
-		#thread_C.start()
+		thread_C.start()
 	except:
 		print("Unable to start a new thread")
 

--- a/movement/lane_stepper.py
+++ b/movement/lane_stepper.py
@@ -8,8 +8,11 @@
 # Speed Var. Ratio: 1/64
 # Stride Angle: 5.625 deg. -> NOTE: 360 deg = 4096 * (5.625 / 64)
 
-import RPi.GPIO as GPIO
+import board
+import busio
+import digitalio
 import time
+from adafruit_mcp230xx.mcp23017 import MCP23017
 
 # Define the sequence for the full step (more granular) rotation
 FULL_STEP = [[1,0,0,1],
@@ -28,7 +31,7 @@ HALF_STEP = [[1,0,0,0],
              [0,0,1,1]]
 
 class ItemLaneStepper:
-    def __init__(self, pinA:int, pinB:int, pinC:int, pinD:int, step_mode:list):
+    def __init__(self, pinA, pinB, pinC, pinD, step_mode:list):
         # Helper function to set up the default position/values for the stepper motor
         def pin_setup(pins:list):
             GPIO.setmode(GPIO.BCM)

--- a/movement/test_movement.py
+++ b/movement/test_movement.py
@@ -1,0 +1,62 @@
+#!/usr/bin/python3
+
+import threading
+import lane_stepper as ls
+import platform_stepper as ps
+
+def main():
+	plat_0 = ps.PlatformStepper(0)
+	lane_0 = ls.ItemLaneStepper(0, ls.FULL_STEP)
+	lane_1 = ls.ItemLaneStepper(1, ls.FULL_STEP)
+	lane_2 = ls.ItemLaneStepper(2, ls.FULL_STEP)
+
+	print("SEQUENTIAL TEST STARTING")
+
+	# Example of moving the platform to the location of an item, dispensing, then coming back down
+	# in sequential order
+	plat_0.rotate('cw', 1000, 5)
+
+	lane_0.rotate('cw', 20000, 1)
+
+	plat_0.rotate('ccw', 1000, 5)
+
+	print("SEQUENTIAL TEST ENDING")
+
+
+	print("PARALLEL TEST STARTING")
+
+	# Example of moving the platform to the location of an item, dispensing two at a time, then
+	# coming back down (with parallelization)
+	plat_0.rotate('ccw', 1000, 3)
+
+	# We would need to define the calculations for number of rotations based on how many of
+	# a particular item is being dispensed
+	thread_0 = threading.Thread(target=lane_0.rotate, args=('cw', 10000, 2))
+	thread_1 = threading.Thread(target=lane_1.rotate, args=('cw', 10000, 2))
+	thread_2 = threading.Thread(target=lane_2.rotate, args=('cw', 10000, 2))
+
+	try:
+		# Launch all threads to rotate the three lanes together
+		thread_0.start()
+		thread_1.start()
+		thread_2.start()
+		
+		# Wait for all three to finish
+		thread_0.join()
+		thread_1.join()
+		thread_2.join()
+
+	except:
+		print("Unable to start a new thread")
+
+	plat_0.rotate('cw', 1000, 3)
+
+	print("PARALLEL TEST ENDING")
+
+	# Cleanup
+	lane_0.reset()
+	lane_1.reset()
+	lane_2.reset()
+
+if __name__ == '__main__':
+	main()


### PR DESCRIPTION
Restructured the API for the ItemLane object in order to account for having single stepper motors occupy each MCP23017 module. May need some more refactoring later down the line in order to get the most performance out of each stepper motor in parallel--serial performance is consistent. ItemLanes are now selected via channels to correspond to which I2C address the MCP23017 is located at (3 bits, 0 through 7)