### PR TITLE
Platform Glide Motion + ItemLaneSystem Refactoring

### DIFF
--- a/movement/lane_stepper/example.py
+++ b/movement/lane_stepper/example.py
@@ -1,11 +1,14 @@
 import build.ItemLaneSystem as ils
+import time
 
 sys = ils.ItemLaneSystem()
 
+sys.rotate(4, "cw", 1.0, 10.0)
+
 # Example call to rotate_n where we specify a list of channels, directions, speeds, and rotations
 # for each of the motors described to follow
-print("Rotating 2 (ch 0/1) together with rotate_n")
-sys.rotate_n([0, 1], ["cw", "ccw"], [1.0, 1.0], [1.0, 1.0])
+print("Rotating 2 (ch 0/3) together with rotate_n")
+sys.rotate_n([0, 3], ["cw", "ccw"], [1.0, 1.0], [1.0, 1.0])
 
 print("Rotating 3 (ch 3/4/5) together with rotate_n")
 sys.rotate_n([3, 4, 5], ["cw", "cw", "cw"], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0])

--- a/movement/platform_stepper.py
+++ b/movement/platform_stepper.py
@@ -121,12 +121,21 @@ class PlatformStepper:
             for i in range(step_count):
                 self.step_channel.onestep(direction=dir_mode, style=stepper.DOUBLE)
                 self.position = self.position + (1 if direction == 'cw' else -1)
-                
+               
+                # ii normalizes the ith step to be within the range of [0,1]
                 ii = i / step_count
-                step_sleep = (1 / init_speed) * (1000 * math.pow(ii - 0.5, 10) + 0.02325)
+                step_sleep = (1 / init_speed) * (15.5 * math.pow(ii - 0.5, 4) + 0.02325)
+                
+                # NOTE: the curve above should adjust for speed
+
+                # TODO: need to remove magic numbers
+
+                # Alternate curve
+                # step_sleep = (1 / init_speed) * \
+                #             (3 * math.pi / 20 * math.cos(2 * math.pi * ii) + (4 * math.pi / 25))
 
                 time.sleep(step_sleep)
-                print("Current step_sleep:", step_sleep) 
+                #print("Current step_sleep:", step_sleep) 
             
             with open(self.pos_file, "w") as f:
                 f.write(str(self.position))
@@ -197,7 +206,7 @@ def main():
     def test_motor_A_ease():
         my_stepper = PlatformStepper(0)
         my_stepper.reset_position()
-        my_stepper.rotate_ease('cw', 100, 1)
+        my_stepper.rotate_ease('cw', 100, 3)
 
     # Launch the threads
     try:

--- a/movement/platform_stepper.py
+++ b/movement/platform_stepper.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 
 import time
+import math
 import board
 from adafruit_motor import stepper
 from adafruit_motorkit import MotorKit
@@ -122,8 +123,9 @@ class PlatformStepper:
                 self.position = self.position + (1 if direction == 'cw' else -1)
                 
                 time.sleep(step_sleep)
-                #print("Current step_sleep:", step_sleep) 
+                print("Current step_sleep:", step_sleep) 
                 
+                # Smooting equation for smoother operation
                 step_sleep = step_sleep * 1.01
             
             with open(self.pos_file, "w") as f:
@@ -195,7 +197,7 @@ def main():
     def test_motor_A_ease():
         my_stepper = PlatformStepper(0)
         my_stepper.reset_position()
-        my_stepper.rotate_ease('cw', 10000, 3)
+        my_stepper.rotate_ease('cw', 10000, 7)
 
     # Launch the threads
     try:

--- a/movement/platform_stepper.py
+++ b/movement/platform_stepper.py
@@ -97,6 +97,16 @@ class PlatformStepper:
 
             exit(1)
 
+    # Move the motor in a smooth motion such that platform may go from fast to slow as it
+    # approaches its destination
+    #
+    # Parameters:
+    # -direction: 'cw' for clockwise or 'ccw' for counterclockwise movement
+    # -init_speed: determines the initial speed at which the motor begins moving
+    # -rotations: number of rotations to undertake
+    def rotate_ease(self, direction:str, init_speed:int, rotations:float):
+        pass
+
     # Resets the position of the stepper motor back to the currently-defined zero position
     def reset_position(self):
         if self.position > 0:

--- a/movement/platform_stepper.py
+++ b/movement/platform_stepper.py
@@ -27,6 +27,12 @@ DOUBLE_STEP = 200
 # Defines maximum speed for gliding motion
 MAX_GLIDE_SPEED = 70
 
+# Define constants for the gliding equation for motion
+SLP_MAX = 15.5
+MIDPT = 0.5
+POWER = 4
+SLP_MIN = 0.02325
+
 class PlatformStepper:
     # Perform setup and check whether the position we are loading from is correct or not relative
     # to the expected neutral position of the stepper motor
@@ -99,7 +105,7 @@ class PlatformStepper:
                 # Perform motion smoothing if the glide flag is enabled
                 if glide:
                     ii = i / step_count
-                    step_sleep = (1 / speed) * (15.5 * math.pow(ii - 0.5, 4) + 0.02325)
+                    step_sleep = (1 / speed) * (SLP_MAX * math.pow(ii - MIDPT, POWER) + SLP_MIN)
 
                 time.sleep(step_sleep)
             

--- a/movement/platform_stepper.py
+++ b/movement/platform_stepper.py
@@ -120,7 +120,11 @@ class PlatformStepper:
             for i in range(step_count):
                 self.step_channel.onestep(direction=dir_mode, style=stepper.DOUBLE)
                 self.position = self.position + (1 if direction == 'cw' else -1)
+                
                 time.sleep(step_sleep)
+                #print("Current step_sleep:", step_sleep) 
+                
+                step_sleep = step_sleep * 1.01
             
             with open(self.pos_file, "w") as f:
                 f.write(str(self.position))

--- a/movement/platform_stepper.py
+++ b/movement/platform_stepper.py
@@ -172,20 +172,19 @@ def main():
         my_stepperA.rotate('ccw', 400, 2.5)
         my_stepperA.reset_position()
         print("Position after 3rd reset:", my_stepperA.get_position())
-    
-    # Test for checking whether the platform stepper can ease to a stop rather than simply
-    # stop immediately
-    def test_motor_A_ease():
-        my_stepper = PlatformStepper(0)
-        my_stepper.reset_position()
-        my_stepper.rotate('cw', 70, 3, True)
 
-    # Launch the threads
+        time.sleep(4)
+
+        print("Glide motion test underway...")
+        my_stepperA.rotate('ccw', 70, 4, True)
+        my_stepperA.reset_position()
+        print("Position after 4th reset:", my_stepperA.get_position())
+        
+    # Launch the test sequence
     try:
-        #test_motor_A()
-        test_motor_A_ease()
+        test_motor_A()
     except:
-        print("Unable to start a new thread.")
+        print("Test canceled.")
 
 if __name__ == '__main__':
     main()

--- a/movement/platform_stepper.py
+++ b/movement/platform_stepper.py
@@ -122,11 +122,11 @@ class PlatformStepper:
                 self.step_channel.onestep(direction=dir_mode, style=stepper.DOUBLE)
                 self.position = self.position + (1 if direction == 'cw' else -1)
                 
+                ii = i / step_count
+                step_sleep = (1 / init_speed) * (1000 * math.pow(ii - 0.5, 10) + 0.02325)
+
                 time.sleep(step_sleep)
                 print("Current step_sleep:", step_sleep) 
-                
-                # Smooting equation for smoother operation
-                step_sleep = step_sleep * 1.01
             
             with open(self.pos_file, "w") as f:
                 f.write(str(self.position))
@@ -197,7 +197,7 @@ def main():
     def test_motor_A_ease():
         my_stepper = PlatformStepper(0)
         my_stepper.reset_position()
-        my_stepper.rotate_ease('cw', 10000, 7)
+        my_stepper.rotate_ease('cw', 100, 1)
 
     # Launch the threads
     try:


### PR DESCRIPTION
This pull request introduces an new mode of moving the delivery platform and, more significantly, changes the method in which we drive the ItemLane stepper motors due to the change in hardware.

### Platform Glide Motion

The platform stepper motor's rotate() function now includes an optional Boolean "glide" flag that, when set to true, forces the motion of the stepper motor to accelerate up to a maximum speed and decelerate following a specific quadratic equation (specified in the code). Note that this changes the maximum speed parameter that can be passed into the function, but the function itself will notify a user of the maximum accepted value [0, 70]. The standard flat rotation profile still follows the older scale [0, 10000].

### ItemLaneSystem Rework

The earlier 28BYJ-48 stepper motors used in the item lanes were too weak to move the physical prototype, so we replaced them with NEMA-17s but run them using a half-step technique for precision and smoother motion. This move to half-stepping was required to account for full-step motion being inconsistent when performing one whole rotation.

Instead of using more Adafruit Stepper Motor HATs to drive these new item lane motors, we now use an array of L298N driver boards to drive each of them using a 6V/5A power supply so that the motors may have enough current to run with the most torque possible to drive the product belts. Multithreading is not an issue when using the motors so long as they are run on separate MCP23017 boards at the same time (with at most one being driven per MCP). This requires more testing, but the current solution to this issue is to simply have each MCP correspond to a  _column_ of products so that simultaneous delivery is not impeded by this bug. Thus, channels 0,1, and 2 are the products in the first column and channels 3, 4, and 5 correspond to items in the second column.